### PR TITLE
Drop Ruby Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ NOTE: This is currently in development, so the readme is developer-focused.
 - Node `apt-get install nodejs`
 - Gulp (JS task runner) `npm install -g gulp`
 - Bower `npm intall -g bower`
+- Ruby's SASS (for css compilation) `gem install sass`
 
 # Setup
 Run `npm install` and `bower install`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ NOTE: This is currently in development, so the readme is developer-focused.
 - Node `apt-get install nodejs`
 - Gulp (JS task runner) `npm install -g gulp`
 - Bower `npm intall -g bower`
-- Ruby's SASS (for css compilation) `gem install sass`
 
 # Setup
 Run `npm install` and `bower install`

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,8 @@ var browserify = require('browserify');
 
 var source = require('vinyl-source-stream');
 
+var sass = require('gulp-sass');
+
 
 gulp.task('browserify', function () {
   // TODO(rkofman): Remove source maps unless in DEV
@@ -30,10 +32,7 @@ gulp.task('browserify', function () {
 gulp.task('styles', function () {
   return gulp.src('app/styles/main.scss')
     .pipe(plugins.plumber())
-    .pipe(plugins.rubySass({
-      style: 'expanded',
-      precision: 10
-    }))
+    .pipe(sass().on('error', sass.logError))
     .pipe(plugins.autoprefixer({browsers: ['last 1 version']}))
     .pipe(gulp.dest('tmp/styles'));
 });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gulp-minify-html": "^0.1.6",
     "gulp-mocha": "^2.1.3",
     "gulp-plumber": "^0.6.3",
-    "gulp-ruby-sass": "^0.7.1",
+    "gulp-sass": "^4.0.1",
     "gulp-size": "^1.1.0",
     "gulp-sourcemaps": "^1.2.8",
     "gulp-uglify": "^1.0.1",


### PR DESCRIPTION
I didn't want to deal with installing/setting up Ruby, so I added a JS module in gulp to do similar. 

Let me know if something about the previous settings will get messed up in with this plugin.

sorry for the extra commits.